### PR TITLE
The logger functionality is mostly already implemented in the main branch.

### DIFF
--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -61,7 +61,7 @@ int main(int argc, char *const *argv) {
         g_object_unref(data);
         g_free(datastore);
 
-        g_abort();
+        exit(EXIT_FAILURE);
     }
 
     g_object_unref(data);


### PR DESCRIPTION
Since the logger functionality is mostly already implemented in the main branch, here will be the only commit at all:

- Simply exiting with the `EXIT_FAILURE` exit code instead of `abort()`ing the execution.