### PR TITLE
Log messages through the Unix system logger.

### DIFF
--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -85,11 +85,13 @@ int main(int argc, char *const *argv) {
     g_object_unref(data);
 
     printf(MSG_SERVER_STARTED NEW_LINE,  server_port);
+    g_message(       MSG_SERVER_STARTED, server_port);
     syslog(LOG_INFO, MSG_SERVER_STARTED, server_port);
 
     g_free(datastore);
 
     printf(MSG_SERVER_STOPPED NEW_LINE);
+    g_message(       MSG_SERVER_STOPPED);
     syslog(LOG_INFO, MSG_SERVER_STOPPED);
 
     _cleanup(log_stream, logfile);

--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -40,6 +40,9 @@ int main(int argc, char *const *argv) {
     // Registering the log writer callback.
     g_log_set_writer_func(log_writer, log_stream, NULL);
 
+    // Opening the system logger.
+    openlog(NULL, LOG_CONS | LOG_PID, LOG_DAEMON);
+
     // Getting the daemon settings.
     GKeyFile *settings = _get_settings();
 
@@ -81,13 +84,15 @@ int main(int argc, char *const *argv) {
 
     g_object_unref(data);
 
-    printf(MSG_SERVER_STARTED NEW_LINE, daemon_name, server_port);
+    printf(MSG_SERVER_STARTED NEW_LINE,  daemon_name, server_port);
+    syslog(LOG_INFO, MSG_SERVER_STARTED, daemon_name, server_port);
 
     g_free(datastore);
 
-    _cleanup(log_stream, logfile);
+    printf(MSG_SERVER_STOPPED NEW_LINE,  daemon_name);
+    syslog(LOG_INFO, MSG_SERVER_STOPPED, daemon_name);
 
-    printf(MSG_SERVER_STOPPED NEW_LINE, daemon_name);
+    _cleanup(log_stream, logfile);
 }
 
 // vim:set nu et ts=4 sw=4:

--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -72,7 +72,7 @@ int main(int argc, char *const *argv) {
     GFile *data = g_file_new_for_path(datastore);
 
     if (!g_file_query_exists(data, NULL)) {
-        g_message(ERR_DATASTORE_NOT_FOUND);
+        g_warning(ERR_DATASTORE_NOT_FOUND);
 
         g_object_unref(data);
         g_free(datastore);
@@ -84,13 +84,11 @@ int main(int argc, char *const *argv) {
 
     g_object_unref(data);
 
-    printf(MSG_SERVER_STARTED NEW_LINE,  server_port);
     g_message(       MSG_SERVER_STARTED, server_port);
     syslog(LOG_INFO, MSG_SERVER_STARTED, server_port);
 
     g_free(datastore);
 
-    printf(MSG_SERVER_STOPPED NEW_LINE);
     g_message(       MSG_SERVER_STOPPED);
     syslog(LOG_INFO, MSG_SERVER_STOPPED);
 

--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -74,6 +74,8 @@ int main(int argc, char *const *argv) {
         g_object_unref(data);
         g_free(datastore);
 
+        _cleanup(log_stream, logfile);
+
         exit(EXIT_FAILURE);
     }
 

--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -25,7 +25,7 @@
  * @returns The exit code of the overall termination of the daemon.
  */
 int main(int argc, char *const *argv) {
-    char *daemon_name = argv[0];
+    char *daemon_name __attribute__ ((unused)) = argv[0];
 
     // Creating the log directory.
     GFile *logdir = g_file_new_for_path(LOG_DIR);
@@ -84,13 +84,13 @@ int main(int argc, char *const *argv) {
 
     g_object_unref(data);
 
-    printf(MSG_SERVER_STARTED NEW_LINE,  daemon_name, server_port);
-    syslog(LOG_INFO, MSG_SERVER_STARTED, daemon_name, server_port);
+    printf(MSG_SERVER_STARTED NEW_LINE,  server_port);
+    syslog(LOG_INFO, MSG_SERVER_STARTED, server_port);
 
     g_free(datastore);
 
-    printf(MSG_SERVER_STOPPED NEW_LINE,  daemon_name);
-    syslog(LOG_INFO, MSG_SERVER_STOPPED, daemon_name);
+    printf(MSG_SERVER_STOPPED NEW_LINE);
+    syslog(LOG_INFO, MSG_SERVER_STOPPED);
 
     _cleanup(log_stream, logfile);
 }

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -164,6 +164,9 @@ GKeyFile *_get_settings() {
 
 // Helper function. Makes final pointers cleanups/unrefs, closes streams, etc.
 void _cleanup(GFileOutputStream *log_stream, GFile *logfile) {
+    // Closing the system logger.
+    closelog();
+
     g_output_stream_close((GOutputStream *) log_stream, NULL, NULL);
     g_object_unref(log_stream);
     g_object_unref(logfile);

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -77,10 +77,10 @@ unsigned short get_server_port(GKeyFile *settings) {
         if ((server_port >= MIN_PORT) && (server_port <= MAX_PORT)) {
             return server_port;
         } else {
-            g_message(ERR_PORT_VALID_MUST_BE_POSITIVE_INT); return DEF_PORT;
+            g_warning(ERR_PORT_VALID_MUST_BE_POSITIVE_INT); return DEF_PORT;
         }
     } else {
-        g_message(ERR_PORT_VALID_MUST_BE_POSITIVE_INT); return DEF_PORT;
+        g_warning(ERR_PORT_VALID_MUST_BE_POSITIVE_INT); return DEF_PORT;
     }
 }
 
@@ -156,7 +156,7 @@ GKeyFile *_get_settings() {
             = g_error_matches(error, G_FILE_ERROR, G_FILE_ERROR_NOENT);
 
         if (is_failed) {
-            g_message(ERR_SETTINGS_NOT_FOUND, error->message);
+            g_warning(ERR_SETTINGS_NOT_FOUND, error->message);
         }
 
         return NULL;

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -35,13 +35,16 @@ GLogWriterOutput log_writer(      GLogLevelFlags  log_level,
     GFileOutputStream *log_stream = user_data;
 
     for (gsize i = 0; i < n_fields; i++) {
-        if ((log_level == G_LOG_LEVEL_MESSAGE)
-            && (g_strcmp0(fields[i].key, LOG_KEY_MESSAGE) == 0)) {
+        if (g_strcmp0(fields[i].key, LOG_KEY_MESSAGE) == 0) {
+            FILE *stream = NULL;
+
+            if (log_level == G_LOG_LEVEL_WARNING) { stream = stderr; }
+            if (log_level == G_LOG_LEVEL_MESSAGE) { stream = stdout; }
 
             char *message = g_strconcat(fields[i].value, NEW_LINE, NULL);
 
-            // Writing the log message to stderr.
-            fprintf(stderr, "%s", message);
+            // Writing the log message to an output stream.
+            fprintf(stream, "%s", message);
 
             // Writing the log message to a logfile.
             gssize nbytes = g_output_stream_write((GOutputStream *) log_stream,

--- a/src/busd.h
+++ b/src/busd.h
@@ -39,8 +39,8 @@
 #define ERR_DATASTORE_NOT_FOUND "FATAL: Data store file not found. Quitting..."
 
 // Common notification messages.
-#define MSG_SERVER_STARTED "%s: Server started on port %u"
-#define MSG_SERVER_STOPPED "%s: Server stopped"
+#define MSG_SERVER_STARTED "Server started on port %u"
+#define MSG_SERVER_STOPPED "Server stopped"
 
 /** The path and filename of the daemon settings. */
 #define SETTINGS "./etc/settings.conf"

--- a/src/busd.h
+++ b/src/busd.h
@@ -16,6 +16,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <syslog.h>
 
 #define G_LOG_USE_STRUCTURED // <== To use structured logging.
 


### PR DESCRIPTION
- Adding the possibility to log messages through the **Unix system logger**.
- **Custom logger:** adding the possibility to log messages also to the `stdout` output stream, but not only to `stderr`.
- Replacing `message` log entries for _error-related messages_ with the `warning` log entries.