### PR TITLE
Convert routes buffer into an array of routes.

### DIFF
--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -25,7 +25,7 @@
  * @returns The exit code of the overall termination of the daemon.
  */
 int main(int argc, char *const *argv) {
-    char *daemon_name __attribute__ ((unused)) = argv[0];
+    gchar *daemon_name __attribute__ ((unused)) = argv[0];
 
     // Creating the log directory.
     GFile *logdir = g_file_new_for_path(LOG_DIR);

--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -96,8 +96,6 @@ int main(int argc, char *const *argv) {
     g_input_stream_read((GInputStream *) routes, routes_buff, data_size,
         NULL, NULL);
 
-    printf("%s" NEW_LINE, routes_buff);
-
     gchar** routes_list = g_strsplit(routes_buff, NEW_LINE, 0);
     guint routes_len = g_strv_length(routes_list);
 

--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -92,13 +92,21 @@ int main(int argc, char *const *argv) {
     gssize data_size = g_file_info_get_size(data_info);
 
     // Reading routes from the routes data store.
-    gchar *routes_list = g_malloc(data_size);
-    g_input_stream_read((GInputStream *) routes, routes_list, data_size,
+    gchar *routes_buff = g_malloc(data_size);
+    g_input_stream_read((GInputStream *) routes, routes_buff, data_size,
         NULL, NULL);
 
-    printf("%s" NEW_LINE, routes_list);
+    printf("%s" NEW_LINE, routes_buff);
 
-    g_free(routes_list);
+    gchar** routes_list = g_strsplit(routes_buff, NEW_LINE, 0);
+    guint routes_len = g_strv_length(routes_list);
+
+    for (guint i = 0; i < routes_len; i++) {
+        printf("%s" NEW_LINE, routes_list[i]);
+    }
+
+    g_strfreev(routes_list);
+    g_free(routes_buff);
     g_object_unref(data_info);
     g_input_stream_close((GInputStream *) routes, NULL, NULL);
     g_object_unref(routes);

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -41,7 +41,7 @@ GLogWriterOutput log_writer(      GLogLevelFlags  log_level,
             if (log_level == G_LOG_LEVEL_WARNING) { stream = stderr; }
             if (log_level == G_LOG_LEVEL_MESSAGE) { stream = stdout; }
 
-            char *message = g_strconcat(fields[i].value, NEW_LINE, NULL);
+            gchar *message = g_strconcat(fields[i].value, NEW_LINE, NULL);
 
             // Writing the log message to an output stream.
             fprintf(stream, "%s", message);


### PR DESCRIPTION
- Converting the **routes buffer** into an **array of routes** and printing it out to the console for debug purposes.
- Utilizing the **GLib type system** deeply in the code.