### PR TITLE
Print current local date and time, and a message log level prepending a log message itself.

### DIFF
--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -46,7 +46,7 @@ int main(int argc, char *const *argv) {
     // Getting the daemon settings.
     GKeyFile *settings = _get_settings();
 
-    unsigned short server_port = DEF_PORT;
+    gushort server_port = DEF_PORT;
     gboolean debug_log_enabled __attribute__ ((unused)) = TRUE;
     gchar *datastore = EMPTY_STRING;
 
@@ -89,7 +89,7 @@ int main(int argc, char *const *argv) {
         G_FILE_ATTRIBUTE_STANDARD_SIZE, G_FILE_QUERY_INFO_NONE, NULL, NULL);
 
     // Getting the size of the routes data store.
-    gssize data_size = g_file_info_get_size(data_info);
+    goffset data_size = g_file_info_get_size(data_info);
 
     // Reading routes from the routes data store.
     gchar *routes_buff = g_malloc(data_size);

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -67,10 +67,10 @@ GLogWriterOutput log_writer(      GLogLevelFlags  log_level,
  *
  * @return The port number on which the server has to be run.
  */
-unsigned short get_server_port(GKeyFile *settings) {
+gushort get_server_port(GKeyFile *settings) {
     GError *error = NULL;
 
-    unsigned short server_port
+    gushort server_port
         = g_key_file_get_integer(settings, SERVER_GROUP, SERVER_PORT, &error);
 
     if (server_port != 0) {

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -49,25 +49,38 @@ GLogWriterOutput log_writer(      GLogLevelFlags  log_level,
                 llevel = LOG_LEVEL_INFO;
             }
 
-            GDateTime *date_time = g_date_time_new_now_local();
-            gint year   = g_date_time_get_year        (date_time);
-            gint month  = g_date_time_get_month       (date_time);
-            gint day    = g_date_time_get_day_of_month(date_time);
-            gint hour   = g_date_time_get_hour        (date_time);
-            gint minute = g_date_time_get_minute      (date_time);
-            gint second = g_date_time_get_second      (date_time);
+GDateTime *date_time = g_date_time_new_now_local();
+gchar *year   = g_strdup_printf(DTM_FORMAT, g_date_time_get_year        (date_time));
+gchar *month  = g_strdup_printf(DTM_FORMAT, g_date_time_get_month       (date_time));
+gchar *day    = g_strdup_printf(DTM_FORMAT, g_date_time_get_day_of_month(date_time));
+gchar *hour   = g_strdup_printf(DTM_FORMAT, g_date_time_get_hour        (date_time));
+gchar *minute = g_strdup_printf(DTM_FORMAT, g_date_time_get_minute      (date_time));
+gchar *second = g_strdup_printf(DTM_FORMAT, g_date_time_get_second      (date_time));
 
-            gchar *message = g_strconcat(fields[i].value, NEW_LINE, NULL);
+            gchar *message = g_strconcat("[", year,
+                                         "-", month,
+                                         "-", day,
+                                        "][", hour,
+                                         ":", minute,
+                                         ":", second,
+                                        "][", llevel,
+                                      " ]  ", fields[i].value, NEW_LINE, NULL);
 
             // Writing the log message to an output stream.
-            fprintf(stream, LOG_FORMAT,
-                year, month, day, hour, minute, second, llevel, message);
+            fprintf(stream, LOG_FORMAT, message);
 
             // Writing the log message to a logfile.
             gssize nbytes = g_output_stream_write((GOutputStream *) log_stream,
                 message, strlen(message), NULL, NULL);
 
             g_free(message);
+
+            g_free(second);
+            g_free(minute);
+            g_free(hour  );
+            g_free(day   );
+            g_free(month );
+            g_free(year  );
 
             if (nbytes == -1) { return G_LOG_WRITER_UNHANDLED; }
         }

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -36,15 +36,32 @@ GLogWriterOutput log_writer(      GLogLevelFlags  log_level,
 
     for (gsize i = 0; i < n_fields; i++) {
         if (g_strcmp0(fields[i].key, LOG_KEY_MESSAGE) == 0) {
-            FILE *stream = NULL;
+            FILE  *stream = NULL;
+            gchar *llevel = NULL;
 
-            if (log_level == G_LOG_LEVEL_WARNING) { stream = stderr; }
-            if (log_level == G_LOG_LEVEL_MESSAGE) { stream = stdout; }
+            if (log_level == G_LOG_LEVEL_WARNING) {
+                stream = stderr;
+                llevel = LOG_LEVEL_WARN;
+            }
+
+            if (log_level == G_LOG_LEVEL_MESSAGE) {
+                stream = stdout;
+                llevel = LOG_LEVEL_INFO;
+            }
+
+            GDateTime *date_time = g_date_time_new_now_local();
+            gint year   = g_date_time_get_year        (date_time);
+            gint month  = g_date_time_get_month       (date_time);
+            gint day    = g_date_time_get_day_of_month(date_time);
+            gint hour   = g_date_time_get_hour        (date_time);
+            gint minute = g_date_time_get_minute      (date_time);
+            gint second = g_date_time_get_second      (date_time);
 
             gchar *message = g_strconcat(fields[i].value, NEW_LINE, NULL);
 
             // Writing the log message to an output stream.
-            fprintf(stream, "%s", message);
+            fprintf(stream, LOG_FORMAT,
+                year, month, day, hour, minute, second, llevel, message);
 
             // Writing the log message to a logfile.
             gssize nbytes = g_output_stream_write((GOutputStream *) log_stream,

--- a/src/busd.h
+++ b/src/busd.h
@@ -79,7 +79,8 @@
 #define LOG_LEVEL_WARN "WARN"
 #define LOG_LEVEL_INFO "INFO"
 
-#define LOG_FORMAT "[%u-%u-%u][%u:%u:%u][%s ]  %s"
+#define DTM_FORMAT "%02u"
+#define LOG_FORMAT "%s"
 
 // The log writer callback. Gets called on every message logging attempt.
 GLogWriterOutput log_writer(      GLogLevelFlags,

--- a/src/busd.h
+++ b/src/busd.h
@@ -83,7 +83,7 @@ GLogWriterOutput log_writer(      GLogLevelFlags,
                                   gpointer);
 
 // Retrieves the port number used to run the server, from daemon settings.
-unsigned short get_server_port(GKeyFile *);
+gushort get_server_port(GKeyFile *);
 
 // Identifies whether debug logging is enabled by retrieving
 // the corresponding setting from daemon settings.

--- a/src/busd.h
+++ b/src/busd.h
@@ -76,6 +76,11 @@
 
 #define LOG_KEY_MESSAGE "MESSAGE"
 
+#define LOG_LEVEL_WARN "WARN"
+#define LOG_LEVEL_INFO "INFO"
+
+#define LOG_FORMAT "[%u-%u-%u][%u:%u:%u][%s ]  %s"
+
 // The log writer callback. Gets called on every message logging attempt.
 GLogWriterOutput log_writer(      GLogLevelFlags,
                             const GLogField *,


### PR DESCRIPTION
- Using a simplified (or consolidated) format for a log message and _correctly padded format for date-time pieces_.
- Printing log messages to the console and to a logfile _in the same format_ with the current local date and time, and a message log level.