### PR TITLE
Add the DEBUG log level to log debug messages.

### DIFF
--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -100,7 +100,7 @@ int main(int argc, char *const *argv) {
     guint routes_len = g_strv_length(routes_list);
 
     for (guint i = 0; i < routes_len; i++) {
-        printf("%s" NEW_LINE, routes_list[i]);
+        g_debug(LOG_FORMAT, routes_list[i]);
     }
 
     g_strfreev(routes_list);

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -44,6 +44,11 @@ GLogWriterOutput log_writer(      GLogLevelFlags  log_level,
                 llevel = LOG_LEVEL_WARN;
             }
 
+            if (log_level == G_LOG_LEVEL_DEBUG) {
+                stream = stdout;
+                llevel = LOG_LEVEL_DEBUG;
+            }
+
             if (log_level == G_LOG_LEVEL_MESSAGE) {
                 stream = stdout;
                 llevel = LOG_LEVEL_INFO;
@@ -64,7 +69,9 @@ gchar *second = g_strdup_printf(DTM_FORMAT, g_date_time_get_second      (date_ti
                                          ":", minute,
                                          ":", second,
                                         "][", llevel,
-                                      " ]  ", fields[i].value, NEW_LINE, NULL);
+            (log_level == G_LOG_LEVEL_DEBUG)
+                   ? (      "]" SPACE SPACE)
+                   : (SPACE "]" SPACE SPACE), fields[i].value, NEW_LINE, NULL);
 
             // Writing the log message to an output stream.
             fprintf(stream, LOG_FORMAT, message);

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -163,6 +163,13 @@ gchar *get_routes_datastore(GKeyFile *settings) {
         datastore = g_strconcat(datastore, path_dir,    NULL); }
     if (filename    != NULL) {
         datastore = g_strconcat(datastore, filename,    NULL); }
+    else {
+        g_free(datastore  );
+        g_free(path_dir   );
+        g_free(path_prefix);
+
+        return NULL;
+    }
 
     g_free(filename   );
     g_free(path_dir   );

--- a/src/busd.h
+++ b/src/busd.h
@@ -76,8 +76,9 @@
 
 #define LOG_KEY_MESSAGE "MESSAGE"
 
-#define LOG_LEVEL_WARN "WARN"
-#define LOG_LEVEL_INFO "INFO"
+#define LOG_LEVEL_WARN  "WARN"
+#define LOG_LEVEL_DEBUG "DEBUG"
+#define LOG_LEVEL_INFO  "INFO"
 
 #define DTM_FORMAT "%02u"
 #define LOG_FORMAT "%s"


### PR DESCRIPTION
- Adding the `DEBUG` log level to log _debug_ messages.
- Preferring to use the `g_debug()` macro to log _debug_ messages over standard `printf()`.
- **Bugfix:** When the routes data store filename is `NULL`, returning `NULL`.