### PR TITLE
Routes were preprocessed and are ready to use.

### DIFF
--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -96,13 +96,28 @@ int main(int argc, char *const *argv) {
     g_input_stream_read((GInputStream *) routes, routes_buff, data_size,
         NULL, NULL);
 
-    gchar** routes_list = g_strsplit(routes_buff, NEW_LINE, 0);
+    gchar **routes_list = g_strsplit(routes_buff, NEW_LINE, 0);
     guint routes_len = g_strv_length(routes_list);
 
     for (guint i = 0; i < routes_len; i++) {
         g_debug(LOG_FORMAT, routes_list[i]);
     }
 
+    // |Like|  routes_list =   new ArrayList();
+    GPtrArray *routes_gary = g_ptr_array_new();
+
+//  GRegex *route_id_regex = g_regex_new(ROUTE_ID_REGEX, 0, 0, NULL);
+
+    for (guint i = 0; i < routes_len; i++) {
+        g_ptr_array_add(routes_gary, routes_list[i]);
+//      g_ptr_array_add(routes_gary, g_regex_replace(route_id_regex,
+//          routes_list[i], -1, 0, EMPTY_STRING, 0, NULL));
+
+        g_debug(LOG_FORMAT, (gchar *) g_ptr_array_index(routes_gary, i));
+    }
+
+//  g_regex_unref(route_id_regex);
+    g_ptr_array_unref(routes_gary);
     g_strfreev(routes_list);
     g_free(routes_buff);
     g_object_unref(data_info);

--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -97,26 +97,32 @@ int main(int argc, char *const *argv) {
         NULL, NULL);
 
     gchar **routes_list = g_strsplit(routes_buff, NEW_LINE, 0);
-    guint routes_len = g_strv_length(routes_list);
+    guint routes_len = g_strv_length(routes_list) - 1;
 
-    for (guint i = 0; i < routes_len; i++) {
-        g_debug(LOG_FORMAT, routes_list[i]);
-    }
+//  for (guint i = 0; i < routes_len; i++) {
+//      g_debug(LOG_FORMAT, routes_list[i]);
+//  }
 
     // |Like|  routes_list =   new ArrayList();
     GPtrArray *routes_gary = g_ptr_array_new();
 
-//  GRegex *route_id_regex = g_regex_new(ROUTE_ID_REGEX, 0, 0, NULL);
+    GRegex *route_id_regex = g_regex_new(ROUTE_ID_REGEX, 0, 0, NULL);
 
     for (guint i = 0; i < routes_len; i++) {
-        g_ptr_array_add(routes_gary, routes_list[i]);
-//      g_ptr_array_add(routes_gary, g_regex_replace(route_id_regex,
-//          routes_list[i], -1, 0, EMPTY_STRING, 0, NULL));
+        gchar *route_ = g_strconcat(routes_list[i], SPACE, NULL);
+        gchar *route  = g_regex_replace(route_id_regex, route_, -1, 0,
+            EMPTY_STRING, 0, NULL);
 
-        g_debug(LOG_FORMAT, (gchar *) g_ptr_array_index(routes_gary, i));
+        g_ptr_array_add(routes_gary, route);
+
+        g_debug("%u" SPACE EQUALS SPACE LOG_FORMAT, (i + 1),
+            (gchar *) g_ptr_array_index(routes_gary, i));
+
+        g_free(route );
+        g_free(route_);
     }
 
-//  g_regex_unref(route_id_regex);
+    g_regex_unref(route_id_regex);
     g_ptr_array_unref(routes_gary);
     g_strfreev(routes_list);
     g_free(routes_buff);

--- a/src/busd.h
+++ b/src/busd.h
@@ -83,6 +83,13 @@
 #define DTM_FORMAT "%02u"
 #define LOG_FORMAT "%s"
 
+/**
+ * The regex pattern for the element to be excluded from a bus stops sequence:
+ * it is an arbitrary identifier of a route, which is not used
+ * in the routes processing anyhow.
+ */
+#define ROUTE_ID_REGEX "^\\d+"
+
 // The log writer callback. Gets called on every message logging attempt.
 GLogWriterOutput log_writer(      GLogLevelFlags,
                             const GLogField *,


### PR DESCRIPTION
- Transforming the **routes list** which is in fact an _array of strings_, into a _dynamic array of pointers_ to simplify further regex ops over it.
- Excluding route IDs from all the routes in the bus routes list using regex ops.
- Adding a constant: the regex pattern for the element to be excluded from a bus stops sequence: it is an arbitrary identifier of a route, which is not used in the routes processing anyhow.