### PR TITLE
Attach the Unix signal handler `SIGINT` to ensure daemon clean shutdown.

### DIFF
--- a/src/bus-controller.c
+++ b/src/bus-controller.c
@@ -22,16 +22,21 @@
  * @param debug_log_enabled The debug logging enabler.
  * @param routes_list       The pointer to an array containing
  *                          all available routes.
+ * @param cleanup_args      The pointer to a structure that holds arguments
+ *                          for the <code>_cleanup()</code> helper function.
  *
  * @returns A new <code>GMainLoop</code> main loop instance.
  */
-GMainLoop *startup(const gushort    server_port,
-                   const gboolean   debug_log_enabled,
-                   const GPtrArray *routes_list) {
+GMainLoop *startup(const gushort        server_port,
+                   const gboolean       debug_log_enabled,
+                   const GPtrArray     *routes_list,
+                         _CLEANUP_ARGS *cleanup_args) {
 
     // Creating the Soup web server and the main loop.
     SoupServer *server = soup_server_new(SERVER_HEADER, EMPTY_STRING, NULL);
     GMainLoop  *loop   = g_main_loop_new(NULL, FALSE);
+
+    g_unix_signal_add(SIGINT, (GSourceFunc) _cleanup, cleanup_args);
 
     GError *error = NULL;
 

--- a/src/bus-controller.c
+++ b/src/bus-controller.c
@@ -36,6 +36,8 @@ GMainLoop *startup(const gushort        server_port,
     SoupServer *server = soup_server_new(SERVER_HEADER, EMPTY_STRING, NULL);
     GMainLoop  *loop   = g_main_loop_new(NULL, FALSE);
 
+    cleanup_args->loop = loop;
+
     g_unix_signal_add(SIGINT, (GSourceFunc) _cleanup, cleanup_args);
 
     GError *error = NULL;

--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -129,8 +129,8 @@ int main(int argc, char *const *argv) {
     }
 
     // Starting up the Soup web server and the main loop.
-    GMainLoop *loop = startup(server_port, debug_log_enabled, routes_gary,
-        _cleanup_args);
+    GMainLoop *loop __attribute__ ((unused)) = startup(server_port,
+        debug_log_enabled, routes_gary, _cleanup_args);
 
     g_regex_unref(route_id_regex);
     g_ptr_array_unref(routes_gary);
@@ -145,8 +145,6 @@ int main(int argc, char *const *argv) {
     g_message(       MSG_SERVER_STOPPED);
     syslog(LOG_INFO, MSG_SERVER_STOPPED);
 
-    _cleanup_args->loop = loop;
-    _cleanup(_cleanup_args);
     free(_cleanup_args);
 }
 

--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -71,13 +71,19 @@ int main(int argc, char *const *argv) {
 
     GFile *data = g_file_new_for_path(datastore);
 
+    _CLEANUP_ARGS *_cleanup_args = malloc(sizeof(_CLEANUP_ARGS));
+    _cleanup_args->log_stream    = log_stream;
+    _cleanup_args->logfile       = logfile;
+    _cleanup_args->loop          = NULL;
+
     if (!g_file_query_exists(data, NULL)) {
         g_warning(ERR_DATASTORE_NOT_FOUND);
 
         g_object_unref(data);
         g_free(datastore);
 
-        _cleanup(log_stream, logfile, NULL);
+        _cleanup(_cleanup_args);
+        free(_cleanup_args);
 
         exit(EXIT_FAILURE);
     }
@@ -123,7 +129,8 @@ int main(int argc, char *const *argv) {
     }
 
     // Starting up the Soup web server and the main loop.
-    GMainLoop *loop = startup(server_port, debug_log_enabled, routes_gary);
+    GMainLoop *loop = startup(server_port, debug_log_enabled, routes_gary,
+        _cleanup_args);
 
     g_regex_unref(route_id_regex);
     g_ptr_array_unref(routes_gary);
@@ -138,7 +145,9 @@ int main(int argc, char *const *argv) {
     g_message(       MSG_SERVER_STOPPED);
     syslog(LOG_INFO, MSG_SERVER_STOPPED);
 
-    _cleanup(log_stream, logfile, loop);
+    _cleanup_args->loop = loop;
+    _cleanup(_cleanup_args);
+    free(_cleanup_args);
 }
 
 // vim:set nu et ts=4 sw=4:

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -210,15 +210,16 @@ GKeyFile *_get_settings() {
 }
 
 // Helper function. Makes final pointers cleanups/unrefs, closes streams, etc.
-void _cleanup(GFileOutputStream *log_stream, GFile *logfile, GMainLoop *loop) {
+void _cleanup(_CLEANUP_ARGS *cleanup_args) {
     // Closing the system logger.
     closelog();
 
-    g_output_stream_close((GOutputStream *) log_stream, NULL, NULL);
-    g_object_unref(log_stream);
-    g_object_unref(logfile);
+    g_output_stream_close((GOutputStream *)
+                   cleanup_args->log_stream, NULL, NULL);
+    g_object_unref(cleanup_args->log_stream);
+    g_object_unref(cleanup_args->logfile);
 
-    g_main_loop_quit(loop);
+    g_main_loop_quit(cleanup_args->loop);
 }
 
 // vim:set nu et ts=4 sw=4:

--- a/src/busd.h
+++ b/src/busd.h
@@ -20,6 +20,7 @@
 #define G_LOG_USE_STRUCTURED // <== To use structured logging.
 
 #include <libsoup/soup.h>
+#include <glib-unix.h>
 
 // Helper constants.
 #define EMPTY_STRING ""
@@ -107,12 +108,22 @@ gboolean is_debug_log_enabled(GKeyFile *);
 // from daemon settings.
 gchar *get_routes_datastore(GKeyFile *);
 
+// Helper structure to hold args for the `_cleanup()` helper function.
+typedef struct {
+    GFileOutputStream *log_stream;
+    GFile             *logfile;
+    GMainLoop         *loop;
+} _CLEANUP_ARGS;
+
 // Starts up the Soup web server and the main loop.
-GMainLoop *startup(const gushort, const gboolean, const GPtrArray *);
+GMainLoop *startup(const gushort,
+                   const gboolean,
+                   const GPtrArray *,
+                         _CLEANUP_ARGS *);
 
 // Helper protos.
 GKeyFile *_get_settings();
-void _cleanup(GFileOutputStream *, GFile *, GMainLoop *);
+void _cleanup(_CLEANUP_ARGS *);
 
 #endif//BUSD_H
 


### PR DESCRIPTION
- Introducing a _helper structure_ to hold argumens for the `_cleanup()` helper function.
- Attaching the **Unix signal handler** `SIGINT` to ensure daemon clean shutdown.
- **Bugfix:** Don't forget passing a real current main loop object to the Unix signal handler and don't clean up twice its resources, because it was quitted already.