### PR TITLE
Incorporate the JSON-GLib library and build the daemon against it to produce HTTP responses in JSON.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Urban bus routing microservice prototype (C port). Version 0.1.1
+# Urban bus routing microservice prototype (C port). Version 0.1.2
 # =============================================================================
 # A daemon written in C (GNOME/libsoup), designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ CFLAGS = -Wall -std=$(CSTD) -march=x86-64 -O3 -pipe -c
 MKDIR   = mkdir
 RMFLAGS = -vR
 
-CFLAGS += `pkg-config --cflags-only-I libsoup-3.0`
-LDLIBS  = `pkg-config   --libs-only-l libsoup-3.0`
+CFLAGS += `pkg-config --cflags-only-I libsoup-3.0 json-glib-1.0`
+LDLIBS  = `pkg-config   --libs-only-l libsoup-3.0 json-glib-1.0`
 
 LDFLAGS = -o $(EXEC)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Urban bus routing microservice prototype (C port). Version 0.1.1
+# Urban bus routing microservice prototype (C port). Version 0.1.2
 # =============================================================================
 # A daemon written in C (GNOME/libsoup), designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ $ make clean
 rm -f -vR bin src/bus-core.o src/bus-controller.o src/bus-handler.o src/bus-helper.o
 $
 $ make all  # <== Building the daemon.
-cc -Wall -std=c99 -march=x86-64 -O3 -pipe -c `pkg-config --cflags-only-I libsoup-3.0` src/bus-core.c -o src/bus-core.o
-cc -Wall -std=c99 -march=x86-64 -O3 -pipe -c `pkg-config --cflags-only-I libsoup-3.0` src/bus-controller.c -o src/bus-controller.o
-cc -Wall -std=c99 -march=x86-64 -O3 -pipe -c `pkg-config --cflags-only-I libsoup-3.0` src/bus-handler.c -o src/bus-handler.o
-cc -Wall -std=c99 -march=x86-64 -O3 -pipe -c `pkg-config --cflags-only-I libsoup-3.0` src/bus-helper.c -o src/bus-helper.o
+cc -Wall -std=c99 -march=x86-64 -O3 -pipe -c `pkg-config --cflags-only-I libsoup-3.0 json-glib-1.0` src/bus-core.c -o src/bus-core.o
+cc -Wall -std=c99 -march=x86-64 -O3 -pipe -c `pkg-config --cflags-only-I libsoup-3.0 json-glib-1.0` src/bus-controller.c -o src/bus-controller.o
+cc -Wall -std=c99 -march=x86-64 -O3 -pipe -c `pkg-config --cflags-only-I libsoup-3.0 json-glib-1.0` src/bus-handler.c -o src/bus-handler.o
+cc -Wall -std=c99 -march=x86-64 -O3 -pipe -c `pkg-config --cflags-only-I libsoup-3.0 json-glib-1.0` src/bus-helper.c -o src/bus-helper.o
 if [ ! -d bin ]; then \
     mkdir bin; \
 fi
-tcc `pkg-config   --libs-only-l libsoup-3.0` -o bin/busd src/bus-core.o src/bus-controller.o src/bus-handler.o src/bus-helper.o
+tcc `pkg-config   --libs-only-l libsoup-3.0 json-glib-1.0` -o bin/busd src/bus-core.o src/bus-controller.o src/bus-handler.o src/bus-helper.o
 ```
 
 ## Running

--- a/etc/settings.conf
+++ b/etc/settings.conf
@@ -1,7 +1,7 @@
 #
 # etc/settings.conf
 # =============================================================================
-# Urban bus routing microservice prototype (C port). Version 0.1.1
+# Urban bus routing microservice prototype (C port). Version 0.1.2
 # =============================================================================
 # A daemon written in C (GNOME/libsoup), designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/src/bus-controller.c
+++ b/src/bus-controller.c
@@ -1,7 +1,7 @@
 /*
  * src/bus-controller.c
  * ============================================================================
- * Urban bus routing microservice prototype (C port). Version 0.1.1
+ * Urban bus routing microservice prototype (C port). Version 0.1.2
  * ============================================================================
  * A daemon written in C (GNOME/libsoup), designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.

--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -1,7 +1,7 @@
 /*
  * src/bus-core.c
  * ============================================================================
- * Urban bus routing microservice prototype (C port). Version 0.1.1
+ * Urban bus routing microservice prototype (C port). Version 0.1.2
  * ============================================================================
  * A daemon written in C (GNOME/libsoup), designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.

--- a/src/bus-handler.c
+++ b/src/bus-handler.c
@@ -41,13 +41,33 @@ void request_handler(      SoupServer        *server,
         soup_server_message_set_status(msg,
             SOUP_STATUS_METHOD_NOT_ALLOWED, NULL);
 
+        // TODO: Set response header: "allow: GET, HEAD".
+
         return;
     }
 
     if (g_strcmp0(path, SLASH REST_PREFIX SLASH REST_DIRECT) != 0) {
         g_debug("[%s]", path);
 
-        soup_server_message_set_status(msg, SOUP_STATUS_BAD_REQUEST, NULL);
+        soup_server_message_set_status(msg, SOUP_STATUS_NOT_FOUND, NULL);
+
+        JsonObject    *json_object = json_object_new();
+        JsonNode      *json_node   = json_node_new(JSON_NODE_OBJECT);
+        JsonGenerator *json_gen    = json_generator_new();
+        GString       *json_body   = g_string_new(NULL);
+
+        json_object_set_string_member(json_object, ERROR_JSON_KEY,
+            ERROR_JSON_VAL_NOT_FOUND);
+        json_node = json_node_init_object(json_node, json_object);
+        json_generator_set_root(json_gen, json_node);
+        json_body = json_generator_to_gstring(json_gen, json_body);
+
+        soup_server_message_set_response(msg, MIME_TYPE, SOUP_MEMORY_COPY,
+            json_body->str, json_body->len);
+
+        g_string_free(json_body, TRUE);
+        json_node_free(json_node);
+        json_object_unref(json_object);
 
         return;
     }

--- a/src/bus-handler.c
+++ b/src/bus-handler.c
@@ -1,7 +1,7 @@
 /*
  * src/bus-handler.c
  * ============================================================================
- * Urban bus routing microservice prototype (C port). Version 0.1.1
+ * Urban bus routing microservice prototype (C port). Version 0.1.2
  * ============================================================================
  * A daemon written in C (GNOME/libsoup), designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -1,7 +1,7 @@
 /*
  * src/bus-helper.c
  * ============================================================================
- * Urban bus routing microservice prototype (C port). Version 0.1.1
+ * Urban bus routing microservice prototype (C port). Version 0.1.2
  * ============================================================================
  * A daemon written in C (GNOME/libsoup), designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.

--- a/src/busd.h
+++ b/src/busd.h
@@ -1,7 +1,7 @@
 /*
  * src/busd.h
  * ============================================================================
- * Urban bus routing microservice prototype (C port). Version 0.1.1
+ * Urban bus routing microservice prototype (C port). Version 0.1.2
  * ============================================================================
  * A daemon written in C (GNOME/libsoup), designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.

--- a/src/busd.h
+++ b/src/busd.h
@@ -21,6 +21,7 @@
 
 #include <libsoup/soup.h>
 #include <glib-unix.h> // <== Needs this for importing `g_unix_signal_add()`.
+#include <json-glib/json-glib.h>
 
 // Helper constants.
 #define EMPTY_STRING ""
@@ -96,6 +97,11 @@
 // REST URI path-related constants.
 #define REST_PREFIX "route"
 #define REST_DIRECT "direct"
+
+// HTTP response-related constants.
+#define MIME_TYPE                "application/json"
+#define ERROR_JSON_KEY           "error"
+#define ERROR_JSON_VAL_NOT_FOUND "404 Not Found."
 
 /**
  * The regex pattern for the element to be excluded from a bus stops sequence:


### PR DESCRIPTION
- Incorporating the **JSON-GLib** library and building the daemon against it to produce HTTP responses in JSON.
- Producing an _actual response in JSON_ for the HTTP client error `404 Not Found`.
- Bumping version number to **0.1.2**.