### PR TITLE
Add the response header `Allow: GET, HEAD` for the `HTTP 405 Method Not Allowed` response.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Urban bus routing microservice prototype (C port). Version 0.1.2
+# Urban bus routing microservice prototype (C port). Version 0.1.3
 # =============================================================================
 # A daemon written in C (GNOME/libsoup), designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Urban bus routing microservice prototype (C port). Version 0.1.2
+# Urban bus routing microservice prototype (C port). Version 0.1.3
 # =============================================================================
 # A daemon written in C (GNOME/libsoup), designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/etc/settings.conf
+++ b/etc/settings.conf
@@ -1,7 +1,7 @@
 #
 # etc/settings.conf
 # =============================================================================
-# Urban bus routing microservice prototype (C port). Version 0.1.2
+# Urban bus routing microservice prototype (C port). Version 0.1.3
 # =============================================================================
 # A daemon written in C (GNOME/libsoup), designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/src/bus-controller.c
+++ b/src/bus-controller.c
@@ -33,7 +33,7 @@ GMainLoop *startup(const gushort        server_port,
                          _CLEANUP_ARGS *cleanup_args) {
 
     // Creating the Soup web server and the main loop.
-    SoupServer *server = soup_server_new(SERVER_HEADER, EMPTY_STRING, NULL);
+    SoupServer *server = soup_server_new(HDR_SERVER_P, EMPTY_STRING, NULL);
     GMainLoop  *loop   = g_main_loop_new(NULL, FALSE);
 
     cleanup_args->loop = loop;

--- a/src/bus-controller.c
+++ b/src/bus-controller.c
@@ -1,7 +1,7 @@
 /*
  * src/bus-controller.c
  * ============================================================================
- * Urban bus routing microservice prototype (C port). Version 0.1.2
+ * Urban bus routing microservice prototype (C port). Version 0.1.3
  * ============================================================================
  * A daemon written in C (GNOME/libsoup), designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.

--- a/src/bus-core.c
+++ b/src/bus-core.c
@@ -1,7 +1,7 @@
 /*
  * src/bus-core.c
  * ============================================================================
- * Urban bus routing microservice prototype (C port). Version 0.1.2
+ * Urban bus routing microservice prototype (C port). Version 0.1.3
  * ============================================================================
  * A daemon written in C (GNOME/libsoup), designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.

--- a/src/bus-handler.c
+++ b/src/bus-handler.c
@@ -32,16 +32,18 @@ void request_handler(      SoupServer        *server,
                            gpointer           payload) {
 
     const char *method = soup_server_message_get_method(msg);
+    SoupMessageHeaders *resp_headers
+        = soup_server_message_get_response_headers(msg);
 
     g_debug("[%s][%s]", method, path);
 
     if ((g_strcmp0(   method, HTTP_HEAD) != 0)
         && (g_strcmp0(method, HTTP_GET ) != 0)) {
 
+        soup_message_headers_append(resp_headers, HDR_ALLOW_N, HDR_ALLOW_V);
+
         soup_server_message_set_status(msg,
             SOUP_STATUS_METHOD_NOT_ALLOWED, NULL);
-
-        // TODO: Set response header: "allow: GET, HEAD".
 
         return;
     }

--- a/src/bus-handler.c
+++ b/src/bus-handler.c
@@ -1,7 +1,7 @@
 /*
  * src/bus-handler.c
  * ============================================================================
- * Urban bus routing microservice prototype (C port). Version 0.1.2
+ * Urban bus routing microservice prototype (C port). Version 0.1.3
  * ============================================================================
  * A daemon written in C (GNOME/libsoup), designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.

--- a/src/bus-helper.c
+++ b/src/bus-helper.c
@@ -1,7 +1,7 @@
 /*
  * src/bus-helper.c
  * ============================================================================
- * Urban bus routing microservice prototype (C port). Version 0.1.2
+ * Urban bus routing microservice prototype (C port). Version 0.1.3
  * ============================================================================
  * A daemon written in C (GNOME/libsoup), designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.

--- a/src/busd.h
+++ b/src/busd.h
@@ -100,6 +100,8 @@
 
 // HTTP response-related constants.
 #define MIME_TYPE                "application/json"
+#define HDR_ALLOW_N              "Allow"
+#define HDR_ALLOW_V              "GET, HEAD"
 #define ERROR_JSON_KEY           "error"
 #define ERROR_JSON_VAL_NOT_FOUND "404 Not Found."
 

--- a/src/busd.h
+++ b/src/busd.h
@@ -88,8 +88,6 @@
 #define DTM_FORMAT "%02u"
 #define LOG_FORMAT "%s"
 
-#define SERVER_HEADER "server-header"
-
 // Allowed HTTP methods.
 #define HTTP_HEAD "HEAD"
 #define HTTP_GET  "GET"
@@ -100,6 +98,7 @@
 
 // HTTP response-related constants.
 #define MIME_TYPE                "application/json"
+#define HDR_SERVER_P             "server-header"
 #define HDR_ALLOW_N              "Allow"
 #define HDR_ALLOW_V              "GET, HEAD"
 #define ERROR_JSON_KEY           "error"

--- a/src/busd.h
+++ b/src/busd.h
@@ -1,7 +1,7 @@
 /*
  * src/busd.h
  * ============================================================================
- * Urban bus routing microservice prototype (C port). Version 0.1.2
+ * Urban bus routing microservice prototype (C port). Version 0.1.3
  * ============================================================================
  * A daemon written in C (GNOME/libsoup), designed and intended to be run
  * as a microservice, implementing a simple urban bus routing prototype.


### PR DESCRIPTION
- Adding the response header `Allow: GET, HEAD` for the `HTTP 405 Method Not Allowed` response.
- Bumping version number to **0.1.3**.